### PR TITLE
README のリンク中にあるプレイスホルダをアカウントに変えました

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ condate.decide #=> 全ジャンルからランダムに表示
 
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/condate/fork )
+1. Fork it ( https://github.com/yuzoiwasaki/condate/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
## やったこと

`Contributing` の見出し下にある fork 用リンクの中に `[my-github-username]` という文字列が入っていましたが、おそらくそこに yuzoiwasaki さんのアカウントが入るのだと（勝手に）判断し、入れ替えておきました。
修正後のリンク先で正常に fork できることも確認しました :dog: 
